### PR TITLE
Detect more return types

### DIFF
--- a/autotyping/autotyping.py
+++ b/autotyping/autotyping.py
@@ -74,11 +74,41 @@ IMPRECISE_MAGICS = {
     "__reversed__": ("typing", "Iterator"),
     "__await__": ("typing", "Iterator"),
 }
-STR_METHODS = frozenset({
-    "format",
-    "lower",
-    "upper",
-    "title",
+
+# Some methods of str type that have unique enough names.
+STR_STR_METHODS = frozenset({
+    'capitalize',
+    'casefold',
+    'format',
+    'ljust',
+    'lower',
+    'lstrip',
+    'partition',
+    'removeprefix',
+    'removesuffix',
+    'rjust',
+    'rpartition',
+    'rstrip',
+    'strip',
+    'swapcase',
+    'title',
+    'upper',
+})
+STR_BOOL_METHODS = frozenset({
+    'endswith',
+    'isalnum',
+    'isalpha',
+    'isascii',
+    'isdecimal',
+    'isdigit',
+    'isidentifier',
+    'islower',
+    'isnumeric',
+    'isprintable',
+    'isspace',
+    'istitle',
+    'isupper',
+    'startswith',
 })
 
 
@@ -544,14 +574,16 @@ def type_of_expression(expr: libcst.BaseExpression) -> Optional[Type[object]]:
         operator = expr.comparisons[0].operator
         if isinstance(operator, libcst.Is):
             return bool
-    method = get_method_name(expr)
-    if method in STR_METHODS:
+    method = get_str_method_name(expr)
+    if method in STR_STR_METHODS:
         return str
+    if method in STR_BOOL_METHODS:
+        return bool
     return None
 
 
-def get_method_name(expr: libcst.BaseExpression) -> Optional[str]:
-    """If the expression is a calling of a method, return the method name.
+def get_str_method_name(expr: libcst.BaseExpression) -> Optional[str]:
+    """If the expression is a calling of an str method, return the method name.
     """
     if not isinstance(expr, libcst.Call):
         return None

--- a/autotyping/autotyping.py
+++ b/autotyping/autotyping.py
@@ -84,11 +84,10 @@ STR_STR_METHODS = frozenset(
         "ljust",
         "lower",
         "lstrip",
-        "partition",
         "removeprefix",
         "removesuffix",
+        "replace",
         "rjust",
-        "rpartition",
         "rstrip",
         "strip",
         "swapcase",
@@ -576,7 +575,7 @@ def type_of_expression(expr: libcst.BaseExpression) -> Optional[Type[object]]:
         expr.operator, libcst.Not
     ):
         return bool
-    if isinstance(expr, libcst.Comparison):
+    if isinstance(expr, libcst.Comparison) and len(expr.comparisons) == 1:
         operator = expr.comparisons[0].operator
         if isinstance(operator, libcst.Is):
             return bool
@@ -594,7 +593,7 @@ def get_str_method_name(expr: libcst.BaseExpression) -> Optional[str]:
         return None
     if not isinstance(expr.func, libcst.Attribute):
         return None
-    if not isinstance(expr.func.value, libcst.BaseString):
+    if not isinstance(expr.func.value, libcst.SimpleString):
         return None
     return expr.func.attr.value
 

--- a/autotyping/autotyping.py
+++ b/autotyping/autotyping.py
@@ -75,7 +75,7 @@ IMPRECISE_MAGICS = {
     "__await__": ("typing", "Iterator"),
 }
 
-# Some methods of str type that have unique enough names.
+# Some methods of str mapped to their return types.
 STR_STR_METHODS = frozenset({
     'capitalize',
     'casefold',

--- a/autotyping/autotyping.py
+++ b/autotyping/autotyping.py
@@ -76,40 +76,44 @@ IMPRECISE_MAGICS = {
 }
 
 # Some methods of str mapped to their return types.
-STR_STR_METHODS = frozenset({
-    'capitalize',
-    'casefold',
-    'format',
-    'ljust',
-    'lower',
-    'lstrip',
-    'partition',
-    'removeprefix',
-    'removesuffix',
-    'rjust',
-    'rpartition',
-    'rstrip',
-    'strip',
-    'swapcase',
-    'title',
-    'upper',
-})
-STR_BOOL_METHODS = frozenset({
-    'endswith',
-    'isalnum',
-    'isalpha',
-    'isascii',
-    'isdecimal',
-    'isdigit',
-    'isidentifier',
-    'islower',
-    'isnumeric',
-    'isprintable',
-    'isspace',
-    'istitle',
-    'isupper',
-    'startswith',
-})
+STR_STR_METHODS = frozenset(
+    {
+        "capitalize",
+        "casefold",
+        "format",
+        "ljust",
+        "lower",
+        "lstrip",
+        "partition",
+        "removeprefix",
+        "removesuffix",
+        "rjust",
+        "rpartition",
+        "rstrip",
+        "strip",
+        "swapcase",
+        "title",
+        "upper",
+    }
+)
+STR_BOOL_METHODS = frozenset(
+    {
+        "endswith",
+        "isalnum",
+        "isalpha",
+        "isascii",
+        "isdecimal",
+        "isdigit",
+        "isidentifier",
+        "islower",
+        "isnumeric",
+        "isprintable",
+        "isspace",
+        "istitle",
+        "isupper",
+        "startswith",
+    }
+)
 
 
 class AutotypeCommand(VisitorBasedCodemodCommand):
@@ -568,7 +572,9 @@ def type_of_expression(expr: libcst.BaseExpression) -> Optional[Type[object]]:
         return None
     if isinstance(expr, libcst.Name) and expr.value in ("True", "False"):
         return bool
-    if isinstance(expr, libcst.UnaryOperation) and isinstance(expr.operator, libcst.Not):
+    if isinstance(expr, libcst.UnaryOperation) and isinstance(
+        expr.operator, libcst.Not
+    ):
         return bool
     if isinstance(expr, libcst.Comparison):
         operator = expr.comparisons[0].operator
@@ -583,8 +589,7 @@ def type_of_expression(expr: libcst.BaseExpression) -> Optional[Type[object]]:
 
 
 def get_str_method_name(expr: libcst.BaseExpression) -> Optional[str]:
-    """If the expression is a calling of an str method, return the method name.
-    """
+    """If the expression is a calling of an str method, return the method name."""
     if not isinstance(expr, libcst.Call):
         return None
     if not isinstance(expr.func, libcst.Attribute):

--- a/autotyping/autotyping.py
+++ b/autotyping/autotyping.py
@@ -538,6 +538,12 @@ def type_of_expression(expr: libcst.BaseExpression) -> Optional[Type[object]]:
         return None
     if isinstance(expr, libcst.Name) and expr.value in ("True", "False"):
         return bool
+    if isinstance(expr, libcst.UnaryOperation) and isinstance(expr.operator, libcst.Not):
+        return bool
+    if isinstance(expr, libcst.Comparison):
+        operator = expr.comparisons[0].operator
+        if isinstance(operator, libcst.Is):
+            return bool
     method = get_method_name(expr)
     if method in STR_METHODS:
         return str

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -58,6 +58,9 @@ class TestAutotype(CodemodTest):
             def return_is(x):
                 return x is object()
 
+            def return_endswith(x):
+                return 'file.exe'.endswith(x)
+
             def baz() -> float:
                 return "not a float"
 
@@ -82,6 +85,9 @@ class TestAutotype(CodemodTest):
 
             def return_is(x) -> bool:
                 return x is object()
+
+            def return_endswith(x) -> bool:
+                return 'file.exe'.endswith(x)
 
             def baz() -> float:
                 return "not a float"

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -52,6 +52,12 @@ class TestAutotype(CodemodTest):
             def formatter(x):
                 return "{}".format(x)
 
+            def return_not(x):
+                return not x
+
+            def return_is(x):
+                return x is object()
+
             def baz() -> float:
                 return "not a float"
 
@@ -70,6 +76,12 @@ class TestAutotype(CodemodTest):
 
             def formatter(x) -> str:
                 return "{}".format(x)
+
+            def return_not(x) -> bool:
+                return not x
+
+            def return_is(x) -> bool:
+                return x is object()
 
             def baz() -> float:
                 return "not a float"


### PR DESCRIPTION
1. `a is b` always returns `bool`
2. `not a` always returns `bool`
3. Support more `str` methods.
