### PR TITLE
drop py36 in more places, ~~update tox~~

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target_version = ['py36', 'py37', 'py38', 'py39']
+target_version = ['py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 
 exclude = '''

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist = py36,py37,py38,py39,py310,py311,black,pyanalyze
+envlist = py37,py38,py39,py310,py311,black,pyanalyze
 
 [testenv]
 deps =


### PR DESCRIPTION
Noticed you dropped 3.6 support, but you forgot to do it in a couple more places.
I also bumped the tox version.