### PR TITLE
add missing 'typing-extensions' dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "libcst",
+    "typing-extensions",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This fixes the tox tests, and makes autotyping usable via pipx.