### PR TITLE
add pre-commit support.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,6 @@
   entry: autotyping
   language: python
   types_or: [python, pyi]
-  args: [--safe, --aggressive]
+  args: [*]
   additional_dependencies: []
   minimum_pre_commit_version: 2.9.2

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: autotyping
+  name: autotyping
+  description: Automatically add simple type-annotations to your code.
+  entry: autotyping
+  language: python
+  types_or: [python, pyi]
+  args: [--safe, --aggressive]
+  additional_dependencies: []
+  minimum_pre_commit_version: 2.9.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ annotations.
 
 # Usage
 
-Here's how to use it:
+Autotyping can be called directly from the CLI, be used as a [pre-commit hook](#pre-commit-hook) or run via the [`libcst` interface](#LibCST) as a codemod.
+Here's how to use it from the CLI:
 
 - `pip install autotyping`
 - `python -m autotyping /path/to/my/code`
@@ -91,6 +92,44 @@ If you wish to run things through the `libcst.tool` interface, you can do this l
 - Make sure you have a `.libcst.codemod.yaml` with `'autotyping'` in the `modules` list.
   For an example, see the `.libcst.codemod.yaml` in this repo.
 - Run `python -m libcst.tool codemod autotyping.AutotypeCommand /path/to/my/code`
+
+
+# pre-commit hook
+
+Pre-commit hooks are scripts that runs automatically before a commit is made,
+which makes them really handy for checking and enforcing code-formatting 
+(or in this case, typing)
+
+1. To add `autotyping` as a [pre-commit](https://pre-commit.com/) hook, 
+you will first need to install pre-commit if you haven't already:
+```
+pip install pre-commit
+```
+
+2. After that, create or update the `.pre-commit-config.yaml` file at the root
+of your repository and add in:
+
+```yaml
+- repos:
+  - repo: https://github.com/JelleZijlstra/autotyping
+    rev:  v24.4.0
+    hooks:
+      - id: autotyping
+        stages: [commit]
+        types: [python]
+        args: [--safe] # or alternatively, --aggressive, see below for how they're different
+```
+
+3. Finally, run the following command to install the pre-commit hook
+in your repository:
+
+```
+pre-commit install
+```
+
+Now whenever you commit changes, autotyping will automatically add
+type annotations to your code!
+
 
 # Limitations
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ of your repository and add in:
       - id: autotyping
         stages: [commit]
         types: [python]
-        args: [--safe] # or alternatively, --aggressive, see below for how they're different
+        args: [--safe] # or alternatively, --aggressive, or any of the other flags mentioned above 
 ```
 
 3. Finally, run the following command to install the pre-commit hook

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 
 [testenv:pyanalyze]
 deps =
-    pyanalyze == 0.12.0
+    pyanalyze == 0.13.1
 commands =
     python -m pyanalyze --config pyproject.toml -v autotyping
 


### PR DESCRIPTION
Adds pre-commit support for the project. I've felt hooks for `--safe` and `--aggressive` should cover most use-cases but I'll be happy to include others if that appears better.

Closes #75.