### PR TITLE
Update .pre-commit-hooks.yaml to work with new pre-commit version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,6 @@
   entry: autotyping
   language: python
   types_or: [python, pyi]
-  args: [*]
+  args: []
   additional_dependencies: []
-  minimum_pre_commit_version: 2.9.2
+  minimum_pre_commit_version: 3.0.0


### PR DESCRIPTION
the current configuration does not work with newer pre-commit versions. In order to be compatible with pre-commit 3+ please apply the following changes